### PR TITLE
pin to go 1.17

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster as dev
+FROM golang:1.17-buster as dev
 
 COPY bashrc /root/.bashrc
 


### PR DESCRIPTION
go get doesn't work on 1.18 the same way, so it's breaking the build