### PR TITLE
chore: update to node 16

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:16-slim
 
 # add curl for healthcheck
 RUN apt-get update \

--- a/vote/src/main/resources/templates/index.html
+++ b/vote/src/main/resources/templates/index.html
@@ -27,7 +27,7 @@
         </div>
     </div>
 </div>
-<script src="http://code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
+<script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.js"></script>
 
 <script th:if="${vote != null}" th:inline="javascript">


### PR DESCRIPTION
Fixes build.

```
------ 
> [2/9] RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*:
#13 0.330 Err:12 http://deb.debian.org/debian stretch-updates/main amd64 Packages
#13 0.331 404 Not Found#13 0.335 Reading package lists...
#13 0.346 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#13 0.347 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#13 0.347 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#13 0.347 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages 404 Not Found [IP: 151.101.66.132 80]
#13 0.347 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages 404 Not Found
#13 0.347 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages 404 Not Found
#13 0.347 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
error building service 'result': error building image 'registry.foo.dev.okteto.net/okteto/microservices-demo-result:05115df982ea6ecef8ddeca47dbb6b42672247eb': build failed: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100 x Error building service 'result': error building image 'registry.foo.dev.okteto.net/okteto/microservices-demo-result:05115df982ea6ecef8ddeca47dbb6b42672247eb': build failed: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100deploy command failed: exit status 1
```