### PR TITLE
set configuration to run just 1 controller

### DIFF
--- a/kafka/values.yml
+++ b/kafka/values.yml
@@ -1,3 +1,6 @@
+controller:
+  replicaCount: 1
+
 zookeeper:
   persistence:
     size: 1Gi


### PR DESCRIPTION
the default on newer versions of Kafka is to use 3 replicas for the controller. That is not needed for the demo, so setting it back to 1