### PR TITLE
Fix worker build

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster as dev
+FROM golang:1.23.4-bookworm AS dev
 
 COPY bashrc /root/.bashrc
 

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/microservicees-demo/worker
 
-go 1.18
+go 1.23
 
 require (
 	github.com/Shopify/sarama v1.30.0


### PR DESCRIPTION
Build of the worker image was failing due to the error `golang.org/x/tools/gopls@latest (in golang.org/x/tools/gopls@v0.17.0): go.mod:5: invalid go version '1.23.1': must match format 1.23`

I'm updating go version of the base image and the go module. I tested it building the image and deploying the sample on my cluster and everything is working fine