### PR TITLE
Fix worker service build

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-bookworm AS dev
+FROM golang:1.24.2-bookworm AS dev
 
 COPY bashrc /root/.bashrc
 

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/microservicees-demo/worker
 
-go 1.23
+go 1.24.2
 
 require (
 	github.com/Shopify/sarama v1.30.0


### PR DESCRIPTION
Build of the service was failing with the following error:

```
=> ERROR [dev 4/9] RUN go install github.com/codegangsta/gin@latest &&     go install github.com/go-delve/delve/cmd/dlv@latest &&     go install golang.org/x/tools/gopls@latest &&     curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin                          37.0s
------                                                                                                                                                                                                                                                                                                                     
 > [dev 4/9] RUN go install github.com/codegangsta/gin@latest &&     go install github.com/go-delve/delve/cmd/dlv@latest &&     go install golang.org/x/tools/gopls@latest &&     curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin:                                      
0.748 go: downloading github.com/codegangsta/gin v0.0.0-20230218063734-2c98d96c9244                                                                                                                                                                                                                                        
0.937 go: finding module for package github.com/0xAX/notificator                                                                                                                                                                                                                                                           
0.937 go: finding module for package github.com/urfave/cli                                                                                                                                                                                                                                                                 
0.938 go: finding module for package github.com/codegangsta/envy/lib                                                                                                                                                                                                                                                       
0.938 go: finding module for package github.com/mattn/go-shellwords
1.457 go: downloading github.com/codegangsta/envy v0.0.0-20141216192214-4b78388c8ce4
1.464 go: downloading github.com/mattn/go-shellwords v1.0.12
1.561 go: downloading github.com/0xAX/notificator v0.0.0-20220220101646-ee9b8921e557
1.561 go: downloading github.com/urfave/cli v1.22.17
1.738 go: found github.com/0xAX/notificator in github.com/0xAX/notificator v0.0.0-20220220101646-ee9b8921e557
1.738 go: found github.com/codegangsta/envy/lib in github.com/codegangsta/envy v0.0.0-20141216192214-4b78388c8ce4
1.738 go: found github.com/mattn/go-shellwords in github.com/mattn/go-shellwords v1.0.12
1.738 go: found github.com/urfave/cli in github.com/urfave/cli v1.22.17
3.513 go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.7
3.547 go: downloading github.com/russross/blackfriday/v2 v2.1.0
18.58 go: downloading github.com/go-delve/delve v1.25.0
19.05 go: downloading github.com/spf13/cobra v1.9.1
19.05 go: downloading golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
19.06 go: downloading github.com/mattn/go-isatty v0.0.20
19.50 go: downloading github.com/spf13/pflag v1.0.6
19.50 go: downloading gopkg.in/yaml.v3 v3.0.1
19.60 go: downloading github.com/hashicorp/golang-lru v1.0.2
19.61 go: downloading golang.org/x/arch v0.11.0
20.19 go: downloading github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d
20.19 go: downloading github.com/cosiner/argv v0.1.0
20.19 go: downloading github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
20.19 go: downloading github.com/google/go-dap v0.12.0
20.59 go: downloading golang.org/x/sys v0.26.0
20.69 go: downloading github.com/cpuguy83/go-md2man/v2 v2.0.6
20.70 go: downloading golang.org/x/sync v0.8.0
20.71 go: downloading github.com/cilium/ebpf v0.11.0
21.27 go: downloading go.starlark.net v0.0.0-20231101134539-556fd59b42f6
21.40 go: downloading github.com/mattn/go-runewidth v0.0.13
21.61 go: downloading github.com/rivo/uniseg v0.2.0
21.74 go: downloading golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
35.20 go: downloading golang.org/x/tools/gopls v0.19.0
35.41 go: downloading golang.org/x/tools v0.34.0
35.99 go: golang.org/x/tools/gopls@latest: golang.org/x/tools/gopls@v0.19.0 requires go >= 1.24.2 (running go 1.23.4; GOTOOLCHAIN=local)
------
 x  Error building service 'worker': build failed: failed to solve: process "/bin/sh -c go install github.com/codegangsta/gin@latest &&     go install github.com/go-delve/delve/cmd/dlv@latest &&     go install golang.org/x/tools/gopls@latest &&     curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin" did not complete successfully: exit code: 1
```