### PR TITLE
Speed up deploy: Kafka probe tuning + Maven build cache

### DIFF
--- a/infrastructure/templates/kafka.yaml
+++ b/infrastructure/templates/kafka.yaml
@@ -98,19 +98,19 @@ spec:
         livenessProbe:
           tcpSocket:
             port: {{ .Values.kafka.service.port }}
-          initialDelaySeconds: 180
-          periodSeconds: 30
+          initialDelaySeconds: 30
+          periodSeconds: 15
           timeoutSeconds: 10
           successThreshold: 1
           failureThreshold: 3
         readinessProbe:
           tcpSocket:
             port: {{ .Values.kafka.service.port }}
-          initialDelaySeconds: 60
-          periodSeconds: 10
+          initialDelaySeconds: 10
+          periodSeconds: 5
           timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 6
         {{- if .Values.kafka.persistence.enabled }}
         volumeMounts:
         - name: data

--- a/infrastructure/values.yaml
+++ b/infrastructure/values.yaml
@@ -13,7 +13,7 @@ postgresql:
     enabled: true
     size: 1Gi
     storageClass: ""
-  
+
   service:
     port: 5432
 
@@ -27,7 +27,7 @@ kafka:
     enabled: true
     size: 1Gi
     storageClass: ""
-  
+
   service:
     port: 9092
   

--- a/vote/Dockerfile
+++ b/vote/Dockerfile
@@ -5,11 +5,11 @@ WORKDIR /app
 
 # Copy only pom.xml first to leverage Docker layer caching
 COPY pom.xml .
-RUN mvn dependency:go-offline -B
+RUN --mount=type=cache,target=/root/.m2 mvn dependency:go-offline -B
 
 # Copy source code and build
 COPY src ./src
-RUN mvn clean package -DskipTests
+RUN --mount=type=cache,target=/root/.m2 mvn clean package -DskipTests
 
 # Runtime stage
 FROM eclipse-temurin:22-jre-jammy


### PR DESCRIPTION
## Summary

- **Kafka readiness probe `initialDelaySeconds` 60 → 10** (period 10→5, failureThreshold 3→6): Kafka KRaft boots in ~10-15s; the 60s delay was artificially holding up every deploy. Liveness probe also tightened from 180s→30s initial delay.
- **Maven `--mount=type=cache,target=/root/.m2`** on both `dependency:go-offline` and `mvn package`: warm vote builds (source change, `pom.xml` unchanged) drop from ~120s to ~69s. Cold builds are unchanged.

## Benchmarks

| Phase | Before | After |
|-------|--------|-------|
| Deploy total | 108s | 55s |
| Pod readiness wait | 72s | ~27s |
| Vote warm build | ~120s | ~69s |

## Test plan

- [x] `okteto deploy --wait` completes successfully (55s)
- [x] `https://vote-rberrelleza.demo.okteto.dev` → HTTP 200
- [x] `https://result-rberrelleza.demo.okteto.dev` → HTTP 200
- [x] Votes submitted via POST flow through Kafka → worker → PostgreSQL → result page
- [x] Worker logs confirm all messages received and processed
- [x] PVCs `kafka-data` and `postgresql-data` both Bound — persistence intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)