### PR TITLE
Fix okteto up for the vote service

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -18,6 +18,11 @@ build:
     dockerfile: Dockerfile
     target: dev
 
+  vote-dev:
+    context: vote
+    dockerfile: Dockerfile
+    target: dev
+
 deploy:
   - helm upgrade --install infrastructure infrastructure/
   - helm upgrade --install vote vote/chart --set image=${OKTETO_BUILD_VOTE_IMAGE}
@@ -29,6 +34,7 @@ forward:
 
 dev:
   vote:
+    image: ${OKTETO_BUILD_VOTE_DEV_IMAGE}
     command: mvn spring-boot:run
     sync:
       - ./vote:/app

--- a/vote/Dockerfile
+++ b/vote/Dockerfile
@@ -11,6 +11,16 @@ RUN --mount=type=cache,target=/root/.m2 mvn dependency:go-offline -B
 COPY src ./src
 RUN --mount=type=cache,target=/root/.m2 mvn clean package -DskipTests
 
+# Dev stage: full Maven + JDK so `okteto up` can run `mvn spring-boot:run`.
+# Dependencies are baked into the image (no cache mount) so startup is fast
+# even without a persistent volume.
+FROM maven:3.9.9-eclipse-temurin-22 AS dev
+
+WORKDIR /app
+
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
 # Runtime stage
 FROM eclipse-temurin:22-jre-jammy
 
@@ -18,6 +28,10 @@ RUN addgroup --system --gid 1001 spring && \
     adduser --system --uid 1001 --gid 1001 spring
 
 WORKDIR /app
+
+# Ensure the non-root user owns the working directory so Okteto file sync
+# (which writes a .stignore file into /app) works during `okteto up`.
+RUN chown spring:spring /app
 
 # Copy the JAR file from builder stage
 COPY --chown=spring:spring --from=builder /app/target/*.jar app.jar


### PR DESCRIPTION
## Summary

Fixes two issues that prevented `okteto up vote` from starting a dev container.

### 1. `.stignore` permission denied
```
cp: cannot create regular file '/app/.stignore': Permission denied
```
The vote runtime image switches to the non-root `spring` user (uid 1001), but `/app` was created by root via `WORKDIR`. Okteto's file sync (syncthing) writes a `.stignore` file into the sync directory and couldn't, because `spring` didn't own `/app`. Fixed by `chown`-ing `/app` to `spring` before the `USER` directive.

### 2. `mvn: not found`
```
sh: 1: mvn: not found
```
The dev command `mvn spring-boot:run` was running against the JRE-only runtime image (`eclipse-temurin:22-jre-jammy`), which has no Maven or JDK. Added a dedicated `dev` build stage based on the full `maven:3.9.9-eclipse-temurin-22` image (with dependencies pre-fetched for fast startup) and pointed the vote dev section at it via `${OKTETO_BUILD_VOTE_DEV_IMAGE}` — mirroring how the `worker` service already does dev images.

## Testing

- `okteto build vote` and `okteto build vote-dev` both build and push successfully.
- Redeployed to `microservices-demo-rb`; both `okteto up` errors are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)