### PR TITLE
Add e2e tests and rename Burritos to Pasta

### DIFF
--- a/e2e/.npmrc
+++ b/e2e/.npmrc
@@ -1,0 +1,1 @@
+loglevel=error

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "End-to-end tests for the microservices-demo voting app",
+  "scripts": {
+    "test": "mocha test/**/*.test.js"
+  },
+  "devDependencies": {
+    "mocha": "^11.0.0"
+  }
+}

--- a/e2e/test/consistency.test.js
+++ b/e2e/test/consistency.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert');
+
+const namespace = process.env.OKTETO_NAMESPACE;
+const domain = process.env.OKTETO_DOMAIN;
+
+if (!namespace || !domain) {
+  throw new Error('OKTETO_NAMESPACE and OKTETO_DOMAIN must be set');
+}
+
+const VOTE_URL = `https://vote-${namespace}.${domain}`;
+const RESULT_URL = `https://result-${namespace}.${domain}`;
+
+async function fetchHTML(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GET ${url} returned ${res.status}`);
+  return res.text();
+}
+
+// Extracts { a, b } labels from the vote service rendered HTML.
+// The vote page renders Thymeleaf buttons: <button id="a" ...>Label</button>
+function extractVoteLabels(html) {
+  const a = html.match(/<button[^>]+id="a"[^>]*>([^<]+)<\/button>/);
+  const b = html.match(/<button[^>]+id="b"[^>]*>([^<]+)<\/button>/);
+  assert.ok(a, 'vote: could not find button#a in HTML');
+  assert.ok(b, 'vote: could not find button#b in HTML');
+  return { a: a[1].trim(), b: b[1].trim() };
+}
+
+// Extracts [optionA, optionB] labels from the result service rendered HTML.
+// The result page has two <div class="label"> elements in order: a then b.
+function extractResultLabels(html) {
+  const matches = [...html.matchAll(/<div class="label">([^<]+)<\/div>/g)];
+  assert.ok(matches.length >= 2, 'result: could not find two .label divs in HTML');
+  return { a: matches[0][1].trim(), b: matches[1][1].trim() };
+}
+
+describe('e2e: vote and result service consistency', function () {
+  this.timeout(15000);
+
+  let voteLabels;
+  let resultLabels;
+
+  before(async function () {
+    const [voteHTML, resultHTML] = await Promise.all([
+      fetchHTML(VOTE_URL),
+      fetchHTML(RESULT_URL),
+    ]);
+    voteLabels = extractVoteLabels(voteHTML);
+    resultLabels = extractResultLabels(resultHTML);
+  });
+
+  it('vote service is reachable', async function () {
+    const res = await fetch(VOTE_URL);
+    assert.ok(res.ok, `vote service at ${VOTE_URL} returned ${res.status}`);
+  });
+
+  it('result service is reachable', async function () {
+    const res = await fetch(RESULT_URL);
+    assert.ok(res.ok, `result service at ${RESULT_URL} returned ${res.status}`);
+  });
+
+  it('vote service exposes a non-empty option A label', function () {
+    assert.ok(voteLabels.a.length > 0, 'option A label is empty in vote service');
+  });
+
+  it('vote service exposes a non-empty option B label', function () {
+    assert.ok(voteLabels.b.length > 0, 'option B label is empty in vote service');
+  });
+
+  it('result service exposes a non-empty option A label', function () {
+    assert.ok(resultLabels.a.length > 0, 'option A label is empty in result service');
+  });
+
+  it('result service exposes a non-empty option B label', function () {
+    assert.ok(resultLabels.b.length > 0, 'option B label is empty in result service');
+  });
+
+  it('option A label matches between vote and result services', function () {
+    assert.strictEqual(
+      voteLabels.a,
+      resultLabels.a,
+      `option A mismatch — vote: "${voteLabels.a}", result: "${resultLabels.a}"`
+    );
+  });
+
+  it('option B label matches between vote and result services', function () {
+    assert.strictEqual(
+      voteLabels.b,
+      resultLabels.b,
+      `option B mismatch — vote: "${voteLabels.b}", result: "${resultLabels.b}"`
+    );
+  });
+});

--- a/okteto.yml
+++ b/okteto.yml
@@ -67,3 +67,10 @@ test:
       - /root/.npm
     commands:
       - cd result && npm install && npm test
+
+  e2e:
+    image: node:22.12.0-slim
+    caches:
+      - /root/.npm
+    commands:
+      - cd e2e && npm install && npm test

--- a/result/views/index.html
+++ b/result/views/index.html
@@ -2,7 +2,7 @@
 <html ng-app="burritosvstacos">
   <head>
     <meta charset="utf-8">
-    <title>Burritos vs Tacos -- Result</title>
+    <title>Pasta vs Tacos -- Result</title>
     <base href="/index.html">
     <meta name = "viewport" content = "width=device-width, initial-scale = 1.0">
     <meta name="keywords" content="docker-compose, docker, stack">
@@ -20,7 +20,7 @@
       <div id="content-container-center">
         <div id="choice">
           <div class="choice burritos">
-            <div class="label">Burritos</div>
+            <div class="label">Pasta</div>
             <div class="stat">{{aPercent | number:1}}%</div>
           </div>
           <div class="divider"></div>

--- a/vote/chart/templates/deployment.yaml
+++ b/vote/chart/templates/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - image: {{ .Values.image }}
         name: vote
+        env:
+        - name: OPTION_A
+          value: {{ .Values.optionA | quote }}
+        - name: OPTION_B
+          value: {{ .Values.optionB | quote }}
         ports:
         - containerPort: 8080
           name: vote

--- a/vote/chart/values.yaml
+++ b/vote/chart/values.yaml
@@ -4,3 +4,5 @@
 
 replicaCount: 1
 image: okteto.dev/vote
+optionA: Pasta
+optionB: Tacos


### PR DESCRIPTION
## Summary

- Renames the vote option A from "Burritos" to "Pasta" in the result service UI and vote chart values
- Adds `OPTION_A` / `OPTION_B` env vars to the vote deployment so options are configurable via Helm values
- Introduces an `e2e/` Mocha test suite that verifies both the vote and result services are reachable and that their option labels are consistent with each other
- Wires the new e2e suite into `okteto.yml` as a new `e2e` test step

## Test plan

- [ ] Deploy to an Okteto preview environment
- [ ] Run `okteto test e2e` — all 8 assertions should pass (reachable, non-empty labels, label consistency between vote and result)
- [ ] Verify the vote page shows "Pasta vs Tacos"
- [ ] Verify the result page shows "Pasta" as option A

🤖 Generated with [Claude Code](https://claude.com/claude-code)